### PR TITLE
Relax trait bounds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub use address::addr::*;
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 #[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
-pub struct IpLookupTable<A, T: Clone + Copy + Default> {
+pub struct IpLookupTable<A, T> {
     inner: TreeBitmap<T>,
     _addrtype: PhantomData<A>,
 }
@@ -424,7 +424,7 @@ where
 /// Iterator over prefixes and associated values. The prefixes are returned in
 /// "tree"-order.
 #[doc(hidden)]
-pub struct Iter<'a, A, T: 'a + Clone + Copy + Default> {
+pub struct Iter<'a, A, T: 'a> {
     inner: tree_bitmap::Iter<'a, T>,
     _addrtype: PhantomData<A>,
 }
@@ -432,7 +432,7 @@ pub struct Iter<'a, A, T: 'a + Clone + Copy + Default> {
 /// Mutable iterator over prefixes and associated values. The prefixes are
 /// returned in "tree"-order.
 #[doc(hidden)]
-pub struct IterMut<'a, A, T: 'a + Clone + Copy + Default> {
+pub struct IterMut<'a, A, T: 'a> {
     inner: tree_bitmap::IterMut<'a, T>,
     _addrtype: PhantomData<A>,
 }
@@ -440,7 +440,7 @@ pub struct IterMut<'a, A, T: 'a + Clone + Copy + Default> {
 /// Converts ```IpLookupTable``` into an iterator. The prefixes are returned in
 /// "tree"-order.
 #[doc(hidden)]
-pub struct IntoIter<A, T: Clone + Copy + Default> {
+pub struct IntoIter<A, T> {
     inner: tree_bitmap::IntoIter<T>,
     _addrtype: PhantomData<A>,
 }

--- a/src/tree_bitmap/allocator.rs
+++ b/src/tree_bitmap/allocator.rs
@@ -188,7 +188,7 @@ pub fn choose_bucket(len: u32) -> u32 {
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 #[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
-pub struct Allocator<T: Sized + Clone + Copy + Default> {
+pub struct Allocator<T: Sized> {
     pub(crate) buckets: [BucketVec<T>; 9],
 }
 

--- a/src/tree_bitmap/mod.rs
+++ b/src/tree_bitmap/mod.rs
@@ -22,7 +22,7 @@ use self::node::{MatchResult, Node};
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 #[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
-pub struct TreeBitmap<T: Sized + Clone + Copy + Default> {
+pub struct TreeBitmap<T: Sized> {
     trienodes: Allocator<Node>,
     results: Allocator<T>,
     len: usize,
@@ -391,13 +391,13 @@ struct PathElem {
     pos: usize,
 }
 
-pub struct Iter<'a, T: 'a + Clone + Copy + Default> {
+pub struct Iter<'a, T: 'a> {
     inner: &'a TreeBitmap<T>,
     path: Vec<PathElem>,
     nibbles: Vec<u8>,
 }
 
-pub struct IterMut<'a, T: 'a + Clone + Copy + Default> {
+pub struct IterMut<'a, T: 'a> {
     inner: &'a mut TreeBitmap<T>,
     path: Vec<PathElem>,
     nibbles: Vec<u8>,
@@ -413,7 +413,7 @@ static PREFIX_OF_BIT: [u8; 32] = [// 0       1       2      3        4       5  
                                   // 24      25      26      27      28      29      30      31
                                   0b1000, 0b1001, 0b1010, 0b1011, 0b1100, 0b1101, 0b1110, 0b1111];
 
-fn next<T: Sized + Clone + Copy + Default>(
+fn next<T: Sized>(
     trie: &TreeBitmap<T>,
     path: &mut Vec<PathElem>,
     nibbles: &mut Vec<u8>,
@@ -488,7 +488,7 @@ impl<'a, T: 'a + Clone + Copy + Default> Iterator for IterMut<'a, T> {
     }
 }
 
-pub struct IntoIter<T: Clone + Copy + Default> {
+pub struct IntoIter<T> {
     inner: TreeBitmap<T>,
     path: Vec<PathElem>,
     nibbles: Vec<u8>,
@@ -526,7 +526,7 @@ impl<T: Clone + Copy + Default> IntoIterator for TreeBitmap<T> {
     }
 }
 
-pub struct MatchesMut<'a, T: 'a + Clone + Copy + Default> {
+pub struct MatchesMut<'a, T: 'a> {
     inner: &'a mut TreeBitmap<T>,
     path: std::vec::IntoIter<(u32, AllocatorHandle, u32)>,
 }
@@ -546,7 +546,7 @@ impl<'a, T: 'a + Clone + Copy + Default> Iterator for MatchesMut<'a, T> {
     }
 }
 
-impl<T: Clone + Copy + Default> TrieAccess for TreeBitmap<T> {
+impl<T> TrieAccess for TreeBitmap<T> {
     fn get_node(&self, hdl: &AllocatorHandle, index: u32) -> Node {
         *self.trienodes.get(&hdl, index)
     }

--- a/src/tree_bitmap/rkyv_impl.rs
+++ b/src/tree_bitmap/rkyv_impl.rs
@@ -108,22 +108,26 @@ mod tests {
 
         let ip_2 = Ipv6Addr::new(0x2001, 0xdb8, 0xcafe, 0xf00, 0xf00, 0xf00, 0, 1);
         assert_eq!(table.longest_match(ip_2), Some((less_specific, 32, &123)));
+        rkyv::to_bytes::<_, 1024>(&table).unwrap();
 
-        let rkyv_bytes = rkyv::to_bytes::<_, 1024>(&table).unwrap();
-        let rkyv_table =
-            rkyv::check_archived_root::<IpLookupTable<Ipv6Addr, i32>>(&rkyv_bytes).unwrap();
+        #[cfg(feature = "bytecheck")]
+        {
+            let rkyv_bytes = rkyv::to_bytes::<_, 1024>(&table).unwrap();
+            let rkyv_table =
+                rkyv::check_archived_root::<IpLookupTable<Ipv6Addr, i32>>(&rkyv_bytes).unwrap();
 
-        assert!(!rkyv_table.is_empty());
-        assert_eq!(rkyv_table.len(), 2);
+            assert!(!rkyv_table.is_empty());
+            assert_eq!(rkyv_table.len(), 2);
 
-        assert_eq!(rkyv_table.exact_match(ip_1, 48), Some(&321));
-        assert_eq!(
-            rkyv_table.longest_match(ip_1),
-            Some((more_specific, 48, &321))
-        );
-        assert_eq!(
-            rkyv_table.longest_match(ip_2),
-            Some((less_specific, 32, &123))
-        );
+            assert_eq!(rkyv_table.exact_match(ip_1, 48), Some(&321));
+            assert_eq!(
+                rkyv_table.longest_match(ip_1),
+                Some((more_specific, 48, &321))
+            );
+            assert_eq!(
+                rkyv_table.longest_match(ip_2),
+                Some((less_specific, 32, &123))
+            );
+        }
     }
 }


### PR DESCRIPTION
Looking at the patch set in [this PR](https://github.com/JakubOnderka/treebitmap/pull/11/), I noticed that the `Clone + Copy + Default` trait bounds were added throughout the crate's public interface, including on the structs.

1. It's generally discouraged to add trait bounds to the structs directly. See [`C-STRUCT-BOUNDS`](https://rust-lang.github.io/api-guidelines/future-proofing.html#data-structures-do-not-duplicate-derived-trait-bounds-c-struct-bounds).
2. Once the bounds are removed from the struct, we can carry that simplification through a number of places.

I made a pass at removing those bounds where it is trivial to do so. There's probably more that can be done to simplify these bounds.

Also, I noticed that one test required both the `rkyv` and `bytecheck` features to be enabled. Assuming we want these features to remain independent (i.e., not bundled together behind a single feature flag), I moved the portion of the test requiring the `bytecheck` crate behind the `bytecheck` feature flag.